### PR TITLE
feat: add openthread addon and mock supervisor api

### DIFF
--- a/argocd/apps/matter-server/base/files/nginx.conf
+++ b/argocd/apps/matter-server/base/files/nginx.conf
@@ -1,0 +1,40 @@
+server {
+    listen 80;
+
+    location /addons/self/options/config {
+        default_type application/json;
+        return 200 '{
+            "result": "ok",
+            "data": {
+                "log_level": "debug",
+                "log_level_sdk": "debug"
+            }
+        }';
+    }
+
+    location /addons/self/info {
+        default_type application/json;
+        return 200 '{
+            "result": "ok",
+            "data": {
+                "arch": ["aarch64", "amd64"],
+                "description": "Matter WebSocket Server for Home Assistant Matter support",
+                "ip_address": "0.0.0.0",
+                "hostname": "matter-server",
+                "name": "Matter Server",
+                "network": {
+                    "5580/tcp": 5580
+                },
+                "slug": "matter_server",
+                "update_available": false,
+                "url": "https://github.com/home-assistant/addons/tree/master/matter_server",
+                "version": "6.6.1",
+                "version_latest": "6.6.1"
+            }
+        }';
+    }
+
+    location / {
+        proxy_pass http://mock-supervisor;
+    }
+}

--- a/argocd/apps/matter-server/base/kustomization.yaml
+++ b/argocd/apps/matter-server/base/kustomization.yaml
@@ -2,12 +2,19 @@ namespace: home-assistant
 
 images:
   - name: homeassistant/aarch64-addon-matter-server
-    newTag: 6.6.0
+    newTag: 6.6.1
+  - name: nginx
+    newTag: 1.27.3
 
 resources:
   - resources/pvc.yaml
   - resources/service.yaml
   - resources/statefulset.yaml
+
+configMapGenerator:
+  - name: matter-supervisor
+    files:
+    - files/nginx.conf
 
 patches:
   # Ensure DNS routes correctly while using multus

--- a/argocd/apps/matter-server/base/patches/multus-interface.yaml
+++ b/argocd/apps/matter-server/base/patches/multus-interface.yaml
@@ -6,4 +6,4 @@ spec:
   template:
     metadata:
       annotations:
-        k8s.v1.cni.cncf.io/networks: '[{"name":"macvlan-conf","namespace":"kube-system","mac":"<matter-server>"}]'
+        k8s.v1.cni.cncf.io/networks: '[{"interface":"<path:vaults/homelab/items/multus-dns-route#supervisor-addons-interface>","name":"macvlan-conf","namespace":"kube-system","mac":"<matter-server>"}]'

--- a/argocd/apps/matter-server/base/resources/statefulset.yaml
+++ b/argocd/apps/matter-server/base/resources/statefulset.yaml
@@ -9,34 +9,25 @@ spec:
   selector:
     matchLabels:
       app: matter-server
-  serviceName: 
   template:
     metadata:
       labels:
         app: matter-server
     spec:
+      # Used to mock supervisor api
+      hostAliases:
+        - ip: "127.0.0.1"
+          hostnames:
+            - "supervisor"
       containers:
+      - name: matter-supervisor
+        image: nginx:latest
+        volumeMounts:
+          - name: nginx-config
+            mountPath: /etc/nginx/conf.d
       - image: homeassistant/aarch64-addon-matter-server:latest
         imagePullPolicy: Always
         name: matter-server
-        command:
-        - matter-server
-        args:
-        - --storage-path
-        - "/data"
-        - --port
-        - $(server_port)
-        - --log-level
-        - $(log_level)
-        - --fabricid
-        - '2'
-        - --vendorid
-        - '4939'
-        env:
-        - name: log_level
-          value: info
-        - name: server_port
-          value: '5580'
         ports:
         - containerPort: 5580
         # Only needed for bluetooth access
@@ -61,6 +52,9 @@ spec:
       - name: data
         persistentVolumeClaim:
           claimName: matter-server
+      - name: nginx-config
+        configMap:
+          name: matter-supervisor
       # Only needed for bluetooth access
       # - name: dbus
       #   hostPath:

--- a/argocd/apps/mock-supervisor/files/nginx.conf
+++ b/argocd/apps/mock-supervisor/files/nginx.conf
@@ -1,0 +1,46 @@
+server {
+    listen 80;
+
+    location /discovery {
+        default_type application/json;
+        return 200 '{"result": "ok"}';
+    }
+
+    location /info {
+        default_type application/json;
+        return 200 '{
+            "result": "ok",
+            "data": {
+                "arch": "arm64",
+                "homeassistant": "2024.11.2",
+                "machine": "raspberrypi4",
+                "operating_system": "Linux",
+                "supervisor": "2024.11.2"
+            }
+        }';
+    }
+
+    location /network/info {
+        default_type application/json;
+        return 200 '{
+            "result": "ok",
+            "data": {
+                "interfaces": [
+                    {
+                        "interface": "<path:vaults/homelab/items/multus-dns-route#supervisor-addons-interface>",
+                        "primary": true
+                    },
+                    {
+                        "interface": "<path:vaults/homelab/items/multus-dns-route#new-interface>",
+                        "primary": false
+                    }
+                ]
+            }
+        }';
+    }
+
+    location /supervisor/ping {
+        default_type application/json;
+        return 200 '{"result": "ok"}';
+    }
+}

--- a/argocd/apps/mock-supervisor/kustomization.yaml
+++ b/argocd/apps/mock-supervisor/kustomization.yaml
@@ -1,0 +1,15 @@
+namespace: home-assistant
+
+images:
+  - name: nginx
+    newTag: 1.27.3
+
+resources:
+  - resources/deployment.yaml
+  - resources/service.yaml
+
+configMapGenerator:
+  - name: mock-supervisor
+    files:
+    - files/nginx.conf
+

--- a/argocd/apps/mock-supervisor/resources/deployment.yaml
+++ b/argocd/apps/mock-supervisor/resources/deployment.yaml
@@ -1,0 +1,27 @@
+# Used for mocking centralized supervisor api
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: mock-supervisor
+  name: mock-supervisor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mock-supervisor
+  template:
+    metadata:
+      labels:
+        app: mock-supervisor
+    spec:
+      containers:
+      - name: mock-supervisor
+        image: nginx:latest
+        volumeMounts:
+          - name: nginx-config
+            mountPath: /etc/nginx/conf.d
+      volumes:
+      - name: nginx-config
+        configMap:
+          name: mock-supervisor

--- a/argocd/apps/mock-supervisor/resources/service.yaml
+++ b/argocd/apps/mock-supervisor/resources/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mock-supervisor
+spec:
+  type: ClusterIP
+  selector:
+    app: mock-supervisor
+  ports:
+    - protocol: TCP
+      port: 80
+      name: http

--- a/argocd/apps/multus/shared/dns-route.yaml
+++ b/argocd/apps/multus/shared/dns-route.yaml
@@ -16,14 +16,21 @@ spec:
             - /bin/sh
           args:
           - -c
+          # Change network adapter name to work with matter-server
           # Add custom route so DNS can reach service CIDR
-          - ip route add $SERVICE_CIDR via $GATEWAY dev $INTERFACE
+          - |
+            ip link set $OLD_INTERFACE down
+            ip link set $OLD_INTERFACE name $NEW_INTERFACE
+            ip link set $NEW_INTERFACE up
+            ip route add $SERVICE_CIDR via $GATEWAY dev $NEW_INTERFACE
           env:
           - name: SERVICE_CIDR
             value: <path:vaults/homelab/items/multus-dns-route#service-cidr>
           - name: GATEWAY
             value: <path:vaults/homelab/items/multus-dns-route#gateway>
-          - name: INTERFACE
-            value: <path:vaults/homelab/items/multus-dns-route#interface>
+          - name: OLD_INTERFACE
+            value: <path:vaults/homelab/items/multus-dns-route#old-interface>
+          - name: NEW_INTERFACE
+            value: <path:vaults/homelab/items/multus-dns-route#new-interface>
           securityContext:
             privileged: true

--- a/argocd/apps/openthread-border-router/overlays/prod/files/nginx.conf
+++ b/argocd/apps/openthread-border-router/overlays/prod/files/nginx.conf
@@ -1,0 +1,46 @@
+server {
+    listen 80;
+
+    location /addons/self/options/config {
+        default_type application/json;
+        return 200 '{
+            "result": "ok",
+            "data": {
+                "autoflash_firmware": true,
+                "baudrate": "460800",
+                "device": "/dev/ttyUSB0",
+                "firewall": true,
+                "flow_control": true,
+                "nat64": false,
+                "otbr_log_level": "notice"
+            }
+        }';
+
+    location /addons/self/info {
+        default_type application/json;
+        return 200 '{
+            "result": "ok",
+            "data": {
+                "arch": ["aarch64", "amd64"],
+                "description": "OpenThread Border Router add-on",
+                "ip_address": "0.0.0.0",
+                "hostname": "openthread-border-router",
+                "name": "OpenThread Border Router",
+                "network": {
+                    "8080/tcp": 8080,
+                    "8081/tcp": 8081
+                },
+                "otbr_log_level": "notice",
+                "slug": "openthread_border_router",
+                "update_available": false,
+                "url": "https://github.com/home-assistant/addons/tree/master/openthread_border_router",
+                "version": "2.12.2",
+                "version_latest": "2.12.2"
+            }
+        }';
+    }
+
+    location / {
+        proxy_pass http://mock-supervisor;
+    }
+}

--- a/argocd/apps/openthread-border-router/overlays/prod/kustomization.yaml
+++ b/argocd/apps/openthread-border-router/overlays/prod/kustomization.yaml
@@ -1,0 +1,17 @@
+namespace: home-assistant
+
+resources:
+  - resources/pvc.yaml
+  - resources/service.yaml
+  - resources/statefulset.yaml
+
+images:
+  - name: homeassistant/aarch64-addon-otbr
+    newTag: 2.12.1
+  - name: nginx
+    newTag: 1.27.3
+
+configMapGenerator:
+  - name: otbr-supervisor-config
+    files:
+    - files/nginx.conf

--- a/argocd/apps/openthread-border-router/overlays/prod/resources/pvc.yaml
+++ b/argocd/apps/openthread-border-router/overlays/prod/resources/pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Delete=false,Prune=false
+  name: openthread-border-router
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/argocd/apps/openthread-border-router/overlays/prod/resources/service.yaml
+++ b/argocd/apps/openthread-border-router/overlays/prod/resources/service.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: openthread-border-router
+  labels:
+    app: openthread-border-router
+spec:
+  selector:
+    app: openthread-border-router
+  ports:
+    - name: web
+      port: 8080
+      protocol: TCP
+      targetPort: web
+    - name: api
+      port: 8081
+      protocol: TCP
+      targetPort: api

--- a/argocd/apps/openthread-border-router/overlays/prod/resources/statefulset.yaml
+++ b/argocd/apps/openthread-border-router/overlays/prod/resources/statefulset.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: openthread-border-router
+  labels:
+    app: openthread-border-router
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openthread-border-router
+  template:
+    metadata:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: '[{"interface":"<path:vaults/homelab/items/multus-dns-route#supervisor-addons-interface>","name":"macvlan-conf","namespace":"kube-system","mac":"<path:vaults/homelab/items/multus-mac#openthread-border-router>"}]'
+      labels:
+        app: openthread-border-router
+    spec:
+      # Used to mock supervisor api
+      hostAliases:
+        - ip: "127.0.0.1"
+          hostnames:
+            - "supervisor"
+      containers:
+        - name: otbr-supervisor
+          image: nginx:latest
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d
+        - name: openthread-border-router
+          image: homeassistant/aarch64-addon-otbr:latest
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+              name: web
+            - containerPort: 8081
+              protocol: TCP
+              name: api
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
+                - NET_ADMIN
+            privileged: true
+          volumeMounts:
+            - name: data
+              mountPath: /data/thread
+              readOnly: false
+            - name: usb-device
+              mountPath: /dev/ttyUSB0
+              readOnly: false
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: openthread-border-router
+        - name: nginx-config
+          configMap:
+            name: otbr-supervisor
+        - name: usb-device
+          hostPath:
+            path: /dev/ttyUSB0
+            type: CharDevice

--- a/argocd/config/prod.yaml
+++ b/argocd/config/prod.yaml
@@ -6,6 +6,10 @@ apps:
     # Ensure multus resources are not deleted (prevents other resource deletion)
     - "PrunePropagationPolicy=orphan"
     wave: "0"
+  - app: mock-supervisor
+    namespace: home-assistant
+    directory: "/"
+    wave: "0"
   - app: onepassword
     namespace: onepassword
     directory: "/"
@@ -54,4 +58,7 @@ apps:
     wave: "3"
   - app: mosquitto
     namespace: mosquitto
+    wave: "3"
+  - app: openthread-border-router
+    namespace: home-assistant
     wave: "3"

--- a/argocd/config/stage.yaml
+++ b/argocd/config/stage.yaml
@@ -6,6 +6,10 @@ apps:
     # Ensure multus resources are not deleted (prevents other resource deletion)
     - "PrunePropagationPolicy=orphan"
     wave: "0"
+  - app: mock-supervisor
+    namespace: home-assistant
+    directory: "/"
+    wave: "0"
   - app: onepassword
     namespace: onepassword
     directory: "/"


### PR DESCRIPTION
- add mock-supervisor app to return centralized home assistant env info
- convert matter-server to use mock supervisor api and update version
- update dns route patch so interface name works with matter sdk
