### PR TITLE
refactor: move home assistant to dedicated device

### DIFF
--- a/argocd/apps/adguard-home/base/files/AdGuardHome.yaml
+++ b/argocd/apps/adguard-home/base/files/AdGuardHome.yaml
@@ -28,33 +28,19 @@ dns:
 
 filtering:
   rewrites:
-    - domain: '<path:vaults/homelab/items/ingress#adguard-home>'
+    - domain: "<path:vaults/homelab/items/ingress#adguard-home>"
       answer: <path:vaults/homelab/items/ingress#ip-address>
-    - domain: '<path:vaults/homelab/items/ingress#argocd>'
+    - domain: "<path:vaults/homelab/items/ingress#argocd>"
       answer: <path:vaults/homelab/items/ingress#ip-address>
-    - domain: '<path:vaults/homelab/items/ingress#argocd-grpc>'
+    - domain: "<path:vaults/homelab/items/ingress#argocd-grpc>"
       answer: <path:vaults/homelab/items/ingress#ip-address>
-    - domain: '<path:vaults/homelab/items/ingress#home-assistant>'
+    - domain: "<path:vaults/homelab/items/ingress#home-assistant>"
       answer: <path:vaults/homelab/items/ingress#ip-address>
-    - domain: '<path:vaults/homelab/items/ingress#homebridge>'
+    - domain: "<path:vaults/homelab/items/ingress#mosquitto>"
       answer: <path:vaults/homelab/items/ingress#ip-address>
-    - domain: '<path:vaults/homelab/items/ingress#mosquitto>'
-      answer: <path:vaults/homelab/items/ingress#ip-address>
-    - domain: '<path:vaults/homelab/items/ingress-stage#adguard-home>'
-      answer: <path:vaults/homelab/items/ingress-stage#ip-address>
-    - domain: '<path:vaults/homelab/items/ingress-stage#argocd>'
-      answer: <path:vaults/homelab/items/ingress-stage#ip-address>
-    - domain: '<path:vaults/homelab/items/ingress-stage#argocd-grpc>'
-      answer: <path:vaults/homelab/items/ingress-stage#ip-address>
-    - domain: '<path:vaults/homelab/items/ingress-stage#home-assistant>'
-      answer: <path:vaults/homelab/items/ingress-stage#ip-address>
-    - domain: '<path:vaults/homelab/items/ingress-stage#homebridge>'
-      answer: <path:vaults/homelab/items/ingress-stage#ip-address>
-    - domain: '<path:vaults/homelab/items/ingress-stage#mosquitto>'
-      answer: <path:vaults/homelab/items/ingress-stage#ip-address>
-    - domain: '<path:vaults/homelab/items/router-dns#http>'
+    - domain: "<path:vaults/homelab/items/router-dns#http>"
       answer: <path:vaults/homelab/items/router-dns#ip-address>
-    - domain: '<path:vaults/homelab/items/router-dns#https>'
+    - domain: "<path:vaults/homelab/items/router-dns#https>"
       answer: <path:vaults/homelab/items/router-dns#ip-address>
 
 tls:

--- a/argocd/apps/ha-ingress/kustomization.yaml
+++ b/argocd/apps/ha-ingress/kustomization.yaml
@@ -1,0 +1,5 @@
+namespace: ha-ingress
+
+resources:
+  - resources/ingress.yaml
+  - resources/service.yaml

--- a/argocd/apps/ha-ingress/resources/ingress.yaml
+++ b/argocd/apps/ha-ingress/resources/ingress.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: home-assistant
+  annotations:
+    avp.kubernetes.io/path: "vaults/homelab/items/ingress"
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.middlewares: kube-system-https-redirect@kubernetescrd,kube-system-ip-allow-list@kubernetescrd
+spec:
+  # Need to specify ingressClass for reasons: https://github.com/argoproj/argo-cd/issues/4863#issuecomment-1516246342
+  ingressClassName: traefik
+  rules:
+    - host: <home-assistant>
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: home-assistant
+                port:
+                  name: http
+  tls:
+    - hosts:
+        - <home-assistant>
+      secretName: home-assistant
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: home-assistant-external
+  annotations:
+    avp.kubernetes.io/path: "vaults/homelab/items/ingress"
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.middlewares: kube-system-https-redirect@kubernetescrd
+spec:
+  # Need to specify ingressClass for reasons: https://github.com/argoproj/argo-cd/issues/4863#issuecomment-1516246342
+  ingressClassName: traefik
+  rules:
+    - host: <home-assistant-external>
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: home-assistant
+                port:
+                  name: http
+  tls:
+    - hosts:
+        - <home-assistant-external>
+      secretName: home-assistant-external

--- a/argocd/apps/ha-ingress/resources/service.yaml
+++ b/argocd/apps/ha-ingress/resources/service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: home-assistant
+spec:
+  ports:
+    - name: http
+      port: 8123
+      targetPort: 8123
+  # no selector, uses endpoint
+---
+apiVersion: v1
+kind: Endpoints
+annotations:
+  avp.kubernetes.io/path: "vaults/homelab/items/ingress"
+metadata:
+  name: home-assistant
+subsets:
+  - addresses:
+      - ip: <ip-address-home-assistant>
+    ports:
+      - name: http
+        port: 8123
+        protocol: TCP

--- a/argocd/config/prod.yaml
+++ b/argocd/config/prod.yaml
@@ -1,15 +1,4 @@
 apps:
-  - app: multus
-    namespace: kube-system
-    directory: "/"
-    syncOptions:
-      # Ensure multus resources are not deleted (prevents other resource deletion)
-      - "PrunePropagationPolicy=orphan"
-    wave: "0"
-  - app: mock-supervisor
-    namespace: home-assistant
-    directory: "/"
-    wave: "0"
   - app: onepassword
     namespace: onepassword
     directory: "/"
@@ -47,15 +36,9 @@ apps:
   - app: cloudflare-ddns
     namespace: cloudflare-ddns
     wave: "3"
-  - app: home-assistant
-    namespace: home-assistant
-    wave: "3"
-  - app: matter-server
-    namespace: home-assistant
+  - app: ha-ingress
+    namespace: ha-ingress
     wave: "3"
   - app: mosquitto
     namespace: mosquitto
-    wave: "3"
-  - app: openthread-border-router
-    namespace: home-assistant
     wave: "3"

--- a/argocd/config/stage.yaml
+++ b/argocd/config/stage.yaml
@@ -1,15 +1,4 @@
 apps:
-  - app: multus
-    namespace: kube-system
-    directory: "/"
-    syncOptions:
-      # Ensure multus resources are not deleted (prevents other resource deletion)
-      - "PrunePropagationPolicy=orphan"
-    wave: "0"
-  - app: mock-supervisor
-    namespace: home-assistant
-    directory: "/"
-    wave: "0"
   - app: onepassword
     namespace: onepassword
     directory: "/"
@@ -46,12 +35,6 @@ apps:
     wave: "3"
   - app: cloudflare-ddns
     namespace: cloudflare-ddns
-    wave: "3"
-  - app: home-assistant
-    namespace: home-assistant
-    wave: "3"
-  - app: matter-server
-    namespace: home-assistant
     wave: "3"
   - app: mosquitto
     namespace: mosquitto


### PR DESCRIPTION
- manually mocking every add on is not worth it
- removes multus dependency, which is not always reliable
- also remove staging dns since we no longer have a staging pi